### PR TITLE
feat: add new project and enhance technology constants

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -193,6 +193,28 @@ export const projects: Project[] = [
     status: "active",
   },
   {
+    title: "Takeout Metadata Fixer",
+    description:
+      "A cross-platform desktop app for Google Takeout archives. It reads Google's JSON sidecars next to photos and videos and writes capture dates, GPS, and related metadata into the media files via ExifTool, so imports into iCloud, a NAS, or other libraries keep correct dates and places.",
+    highlights: [
+      "Wails v3 desktop shell with a Go backend and a Vite-built UI",
+      "Resumable processing using a checkpoint file in the selected Takeout folder",
+      "Pause, resume, and stop with live progress and per-outcome counts",
+      "Optional removal of sidecar JSON after a successful run",
+      "Released macOS DMG and Windows builds via GitHub Releases",
+      "Marketing site at md-fixer.mrashidi.me (Vue 3 + Vite)",
+    ],
+    stack: ["Go", "Wails", "JavaScript", "Vite", "Vue.js", "macOS", "Windows"],
+    githubUrl: "https://github.com/MRdevX/takeout-md-fixer",
+    liveUrl: "https://md-fixer.mrashidi.me",
+    visibility: "public",
+    type: "personal",
+    openSource: true,
+    year: "2026",
+    role: "Creator & Maintainer",
+    status: "active",
+  },
+  {
     title: "Nestifined MS Framework",
     description:
       "A refined and optimized codebase template for setting up NestJS microservices. Provides a streamlined foundation for beginning fresh microservice initiatives with comprehensive tooling and best practices.",

--- a/src/lib/core/constants.ts
+++ b/src/lib/core/constants.ts
@@ -58,8 +58,19 @@ export const ANIMATION = {
 } as const;
 
 export const TECHNOLOGY_CATEGORIES = {
-  frameworks: ["NestJS", "Next.js", "React", "Framer Motion", "TypeORM", "Drizzle ORM", "Hono"],
-  languages: ["TypeScript", "JavaScript", "Python", "Java", "Rust", "Bash"],
+  frameworks: [
+    "NestJS",
+    "Next.js",
+    "React",
+    "Framer Motion",
+    "TypeORM",
+    "Drizzle ORM",
+    "Hono",
+    "Vue.js",
+    "Vite",
+    "Wails",
+  ],
+  languages: ["TypeScript", "JavaScript", "Python", "Java", "Rust", "Bash", "Go"],
   databases: ["PostgreSQL", "MongoDB", "Redis", "Supabase", "PostgREST"],
   clouds: ["AWS", "Azure", "Docker", "Kubernetes"],
 } as const;

--- a/src/lib/tech/icons.tsx
+++ b/src/lib/tech/icons.tsx
@@ -88,7 +88,9 @@ import {
   SiTailwindcss,
   SiTerraform,
   SiTrpc,
+  SiVite,
   SiVitest,
+  SiVuedotjs,
   SiZod,
 } from "react-icons/si";
 import { TbApi, TbBrain, TbBrandCSharp, TbBrandGoogle, TbBrandOauth, TbBrandOpenai, TbLicense } from "react-icons/tb";
@@ -210,6 +212,8 @@ const ICON_DEFINITIONS: Record<string, { Icon: IconType | React.FC<{ className?:
 
   jest: { Icon: SiJest, colorClass: "text-red-500" },
   vitest: { Icon: SiVitest, colorClass: "text-green-500" },
+  vite: { Icon: SiVite, colorClass: "text-purple-500" },
+  vuejs: { Icon: SiVuedotjs, colorClass: "text-green-500" },
   supertest: { Icon: SiJest, colorClass: "text-red-500" },
   unittesting: { Icon: SiJest, colorClass: "text-green-500" },
   integrationtesting: { Icon: SiJest, colorClass: "text-blue-500" },
@@ -320,6 +324,7 @@ const getIconKey = (techName: string): string => {
     next: "nextjs",
     node: "nodejs",
     nest: "nestjs",
+    vue: "vuejs",
     spring: "springboot",
     tailwind: "tailwindcss",
     framer: "framermotion",

--- a/tests/unit/lib/core-constants-tech.test.ts
+++ b/tests/unit/lib/core-constants-tech.test.ts
@@ -10,7 +10,10 @@ describe("technology constants helpers", () => {
 
   it("getTechnologyCategory maps known stack names", () => {
     expect(getTechnologyCategory("TypeScript")).toBe("languages");
+    expect(getTechnologyCategory("Go")).toBe("languages");
     expect(getTechnologyCategory("React")).toBe("frameworks");
+    expect(getTechnologyCategory("Vue.js")).toBe("frameworks");
+    expect(getTechnologyCategory("Vite")).toBe("frameworks");
     expect(getTechnologyCategory("PostgreSQL")).toBe("databases");
     expect(getTechnologyCategory("Docker")).toBe("clouds");
   });


### PR DESCRIPTION
- Introduced "Takeout Metadata Fixer" project with detailed description, highlights, and links.
- Updated technology categories to include "Vue.js", "Vite", and "Go".
- Added corresponding icons for "Vite" and "Vue.js" in the tech icons component.
- Enhanced unit tests to cover new technology categories.